### PR TITLE
format go-list do not marshal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,15 @@
 module github.com/ldez/gomoddirectives
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/mod v0.4.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/module.go
+++ b/module.go
@@ -1,44 +1,31 @@
 package gomoddirectives
 
 import (
-	"encoding/json"
+	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 
 	"golang.org/x/mod/modfile"
 )
 
-type modInfo struct {
-	Path      string `json:"Path"`
-	Dir       string `json:"Dir"`
-	GoMod     string `json:"GoMod"`
-	GoVersion string `json:"GoVersion"`
-	Main      bool   `json:"Main"`
-}
-
 // GetModuleFile gets module file.
 func GetModuleFile() (*modfile.File, error) {
 	// https://github.com/golang/go/issues/44753#issuecomment-790089020
-	cmd := exec.Command("go", "list", "-m", "-json", "-f", "{{.GoMod}}")
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.GoMod}}")
 
 	raw, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("command go list: %w: %s", err, string(raw))
 	}
+	raw = bytes.TrimSpace(raw)
 
-	var v modInfo
-	err = json.Unmarshal(raw, &v)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshaling error: %w: %s", err, string(raw))
-	}
-
-	if v.GoMod == "" {
+	if len(raw) == 0 {
 		return nil, errors.New("working directory is not part of a module")
 	}
 
-	raw, err = ioutil.ReadFile(v.GoMod)
+	raw, err = os.ReadFile(string(raw))
 	if err != nil {
 		return nil, fmt.Errorf("reading go.mod file: %w", err)
 	}


### PR DESCRIPTION
Currently the exec.Cmd that is run contains formatting instructions for
-json and -f, in >go1.17 this just works, as -json takes precidence.
This has becomes an error in go1.17, so we should pick one and just use
that. My preferences is to have go-list do the parsing, use -f, and just
chomp the string before passing it to ioutil.ReadFile.