### PR TITLE
fix: read only STDOUT from "go list"

### DIFF
--- a/module.go
+++ b/module.go
@@ -24,7 +24,7 @@ func GetModuleFile() (*modfile.File, error) {
 	// https://github.com/golang/go/issues/44753#issuecomment-790089020
 	cmd := exec.Command("go", "list", "-m", "-json")
 
-	raw, err := cmd.CombinedOutput()
+	raw, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("command go list: %w: %s", err, string(raw))
 	}


### PR DESCRIPTION
Sometimes, "go list -m -json", outputs valid JSON on STDOUT, but also other messages on STDERR, such as warnings. Restrict ourselves to just parsing the contents of STDOUT to avoid failures while unmarshalling.

As an example of this situation:

```bash
$ GOPATH=$HOME/go GOROOT=$HOME/go go list -m -json 1>out.txt 2>err.txt
$ cat out.txt 
{
        "Path": "github.com/rh-mobb/ocm-operator",
        "Main": true,
        "Dir": "/home/daxelrod/projects/ocm-operator",
        "GoMod": "/home/daxelrod/projects/ocm-operator/go.mod",
        "GoVersion": "1.19"
}
$ cat err.txt 
warning: GOPATH set to GOROOT (/home/daxelrod/go) has no effect
```

Running gomoddirectives under golanci-lint in this situation results in

```
failed to get module file: unmarshaling error: invalid character 'w' looking for beginning of value: warning: GOPATH set to GOROOT (/home/daxelrod/go) has no effect
```

without this PR, and a successful run of gomoddirectives with this PR.

Please let me know if you'd like a unit test written for this case. I haven't written one yet because it didn't seem to fit in to the general structure of the other unit tests that already exist.

Thank you very much for gomoddirectives and golangci-lint!