### PR TITLE
feat: add option to allow all replace directives

### DIFF
--- a/cmd/gomoddirectives/gomoddirectives.go
+++ b/cmd/gomoddirectives/gomoddirectives.go
@@ -24,7 +24,7 @@ func (f *flagSlice) Set(s string) error {
 }
 
 type config struct {
-	ReplaceAllowAny           bool
+	ReplaceAllowAll           bool
 	ReplaceAllowList          flagSlice
 	ReplaceAllowLocal         bool
 	ExcludeForbidden          bool
@@ -43,7 +43,7 @@ func main() {
 
 	flag.BoolVar(&cfg.ExcludeForbidden, "exclude", false, "Forbid the use of exclude directives")
 	flag.BoolVar(&cfg.IgnoreForbidden, "ignore", false, "Forbid the use of ignore directives")
-	flag.BoolVar(&cfg.ReplaceAllowAny, "replace-any", false, "Allow any replace directives")
+	flag.BoolVar(&cfg.ReplaceAllowAll, "all-replace", false, "Allow all replace directives")
 	flag.Var(&cfg.ReplaceAllowList, "list", "List of allowed replace directives")
 	flag.BoolVar(&cfg.ReplaceAllowLocal, "local", false, "Allow local replace directives")
 	flag.BoolVar(&cfg.RetractAllowNoExplanation, "retract-no-explanation", false, "Allow to use retract directives without explanation")
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	opts := gomoddirectives.Options{
-		ReplaceAllowAny:           cfg.ReplaceAllowAny,
+		ReplaceAllowAll:           cfg.ReplaceAllowAll,
 		ReplaceAllowList:          cfg.ReplaceAllowList,
 		ReplaceAllowLocal:         cfg.ReplaceAllowLocal,
 		ExcludeForbidden:          cfg.ExcludeForbidden,

--- a/cmd/gomoddirectives/gomoddirectives.go
+++ b/cmd/gomoddirectives/gomoddirectives.go
@@ -24,6 +24,7 @@ func (f *flagSlice) Set(s string) error {
 }
 
 type config struct {
+	ReplaceAllowAny           bool
 	ReplaceAllowList          flagSlice
 	ReplaceAllowLocal         bool
 	ExcludeForbidden          bool
@@ -42,6 +43,7 @@ func main() {
 
 	flag.BoolVar(&cfg.ExcludeForbidden, "exclude", false, "Forbid the use of exclude directives")
 	flag.BoolVar(&cfg.IgnoreForbidden, "ignore", false, "Forbid the use of ignore directives")
+	flag.BoolVar(&cfg.ReplaceAllowAny, "replace-any", false, "Allow any replace directives")
 	flag.Var(&cfg.ReplaceAllowList, "list", "List of allowed replace directives")
 	flag.BoolVar(&cfg.ReplaceAllowLocal, "local", false, "Allow local replace directives")
 	flag.BoolVar(&cfg.RetractAllowNoExplanation, "retract-no-explanation", false, "Allow to use retract directives without explanation")
@@ -63,6 +65,7 @@ func main() {
 	}
 
 	opts := gomoddirectives.Options{
+		ReplaceAllowAny:           cfg.ReplaceAllowAny,
 		ReplaceAllowList:          cfg.ReplaceAllowList,
 		ReplaceAllowLocal:         cfg.ReplaceAllowLocal,
 		ExcludeForbidden:          cfg.ExcludeForbidden,

--- a/gomoddirectives.go
+++ b/gomoddirectives.go
@@ -52,7 +52,7 @@ func (r Result) String() string {
 
 // Options the analyzer options.
 type Options struct {
-	ReplaceAllowAny           bool
+	ReplaceAllowAll           bool
 	ReplaceAllowList          []string
 	ReplaceAllowLocal         bool
 	ExcludeForbidden          bool
@@ -253,7 +253,7 @@ func checkReplaceDirectives(file *modfile.File, opts Options) []Result {
 }
 
 func checkReplaceDirective(opts Options, r *modfile.Replace) string {
-	if opts.ReplaceAllowAny {
+	if opts.ReplaceAllowAll {
 		return ""
 	}
 

--- a/gomoddirectives.go
+++ b/gomoddirectives.go
@@ -52,6 +52,7 @@ func (r Result) String() string {
 
 // Options the analyzer options.
 type Options struct {
+	ReplaceAllowAny           bool
 	ReplaceAllowList          []string
 	ReplaceAllowLocal         bool
 	ExcludeForbidden          bool
@@ -252,6 +253,10 @@ func checkReplaceDirectives(file *modfile.File, opts Options) []Result {
 }
 
 func checkReplaceDirective(opts Options, r *modfile.Replace) string {
+	if opts.ReplaceAllowAny {
+		return ""
+	}
+
 	if isLocal(r) {
 		if opts.ReplaceAllowLocal {
 			return ""

--- a/gomoddirectives_test.go
+++ b/gomoddirectives_test.go
@@ -48,6 +48,13 @@ func TestAnalyzeFile(t *testing.T) {
 			},
 		},
 		{
+			desc:       "replace: allow all",
+			modulePath: "replace/go.mod",
+			opts: Options{
+				ReplaceAllowAny: true,
+			},
+		},
+		{
 			desc:       "replace: allow an element",
 			modulePath: "replace/go.mod",
 			opts: Options{

--- a/gomoddirectives_test.go
+++ b/gomoddirectives_test.go
@@ -51,7 +51,7 @@ func TestAnalyzeFile(t *testing.T) {
 			desc:       "replace: allow all",
 			modulePath: "replace/go.mod",
 			opts: Options{
-				ReplaceAllowAny: true,
+				ReplaceAllowAll: true,
 			},
 		},
 		{

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,6 @@ linters:
 
   settings:
     gomoddirectives:
-      # Allow any `replace` directives.
-      # Default: false
-      replace-any: true
-
       # Allow local `replace` directives.
       # Default: false
       replace-local: true
@@ -30,7 +26,11 @@ linters:
       # Default: []
       replace-allow-list:
         - launchpad.net/gocheck
-      
+
+      # Allow all `replace` directives.
+      # Default: false
+      replace-allow-all: true
+
       # Allow to not explain why the version has been retracted in the `retract` directives.
       # Default: false
       retract-allow-no-explanation: true
@@ -89,8 +89,8 @@ Flags:
         List of allowed replace directives
   -local
         Allow local replace directives
-  -replace-any
-        Allow any replace directives
+  -all-replace
+        Allow all replace directives
   -retract-no-explanation
         Allow to use retract directives without explanation
   -tool
@@ -124,9 +124,9 @@ retract (
 ### [`replace`](https://golang.org/ref/mod#go-mod-file-replace) directives
 
 - Ban all `replace` directives.
-- Allow any `replace` directives.
 - Allow only local `replace` directives.
 - Allow only some `replace` directives.
+- Allow all `replace` directives.
 - Detect duplicated `replace` directives.
 - Detect identical `replace` directives.
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,10 @@ linters:
 
   settings:
     gomoddirectives:
+      # Allow any `replace` directives.
+      # Default: false
+      replace-any: true
+
       # Allow local `replace` directives.
       # Default: false
       replace-local: true
@@ -85,6 +89,8 @@ Flags:
         List of allowed replace directives
   -local
         Allow local replace directives
+  -replace-any
+        Allow any replace directives
   -retract-no-explanation
         Allow to use retract directives without explanation
   -tool
@@ -118,6 +124,7 @@ retract (
 ### [`replace`](https://golang.org/ref/mod#go-mod-file-replace) directives
 
 - Ban all `replace` directives.
+- Allow any `replace` directives.
 - Allow only local `replace` directives.
 - Allow only some `replace` directives.
 - Detect duplicated `replace` directives.


### PR DESCRIPTION

Thanks for creating this linter! I've been getting use of most of the settings, but the `replace-allow-list` has been an obstacle.

In my organization, we don't want to maintain a list of allowed module replacements for all modules covered by our golangci-lint configuration. There isn't a way to disable the `replace-allow-list` setting since empty/default means allow none.

This PR adds an additional option `replace-allow-all`. When set to true, `replace-allow-list` and `replace-local` are ignored.